### PR TITLE
includes ./bin directory in NPM compilation

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,6 @@
 **/*
+!bin/**/*
 !lib/**/*
-!bin/targz
 !package.json
 !index.js
 !LICENSE

--- a/bin/portastic
+++ b/bin/portastic
@@ -1,4 +1,4 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 
 var portastic = require('../');
 var commander = require('commander');


### PR DESCRIPTION
the `.npmignore` file ignores all files by default and whitelists files to be includes into the package.  This was preventing the successful installation of the package in some versions of node. 

I have locally tested and can say it resolves #3.
