### PR TITLE
Add typescript declarations

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,4 +3,5 @@
 !lib/**/*
 !package.json
 !index.js
+!index.d.ts
 !LICENSE

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,16 @@
+// Type definitions for portastic v1.0.1
+// Project: portastic
+// Definitions by: James Booth github.com/jabooth
+
+export function test(port: number, interface?: string, callback?: Function): Promise<boolean>
+
+export function find(options: {min?: number, max?: number, retrieve?: number},
+                     interface?: string, callback?: Function): Promise<number[]>
+
+export function filter(ports: number[], interface?: string, callback?: Function): Promise<number[]>
+
+import { EventEmitter } from 'events'
+export class Monitor extends EventEmitter {
+    constructor(ports: number[])
+    on(event: "open" | "close", listener: (port: number) => void): this
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.1",
   "description": "Pure javascript swiss knife for port management",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "mocha --tdd --bail test/**/*-test.js",
     "travis": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha --report lcovonly -- -R spec test/**/*-test.js && cat ./coverage/lcov.info | ./node_modules/.bin/coveralls && rm -rf ./coverage"
@@ -28,6 +29,7 @@
   },
   "homepage": "https://github.com/alanhoff/node-portastic#readme",
   "dependencies": {
+    "@types/node": "0.0.2",
     "bluebird": "^2.9.34",
     "commander": "^2.8.1",
     "debug": "^2.2.0"


### PR DESCRIPTION
Hi @alanhoff,

I'm using your library with Typescript, so I thought I would take a bash at writing a Typescript declaration file for portastic. 

If you'd like, you could take this PR, and future TS users of portastic (who just `npm install portastic` as normal) will get to use the typing information provided here without any extra effort. Some tools/IDE's (like VSCode) will even provide typing assistance to normal JS users of the library based on this definition file.

Of course, the downside is that ideally the `index.d.ts` declaration needs to be kept up to date as you change your library, otherwise you will have some very confused TS users ;). I hope you feel the maintenance burden is acceptable - even if you don't know TS at all I imagine you can glance over the definition and not be too surprised about what is going on!

If that sounds like too much trouble, I can submit these definitions to [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped), which is a seperate repository of typing information. TS users will still be able to get types by doing:
```
npm install @types/portastic
```
The beauty of taking this PR instead is that the types can be versioned and kept in sync with the project.

You can read more about this whole thing from the official [TS guide here](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html).

Cheers!