### PR TITLE
Fix monitor.stop to actually stop portastic.

### DIFF
--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -26,7 +26,7 @@ Monitor.prototype.start = function() {
 
 Monitor.prototype.stop = function() {
   this._watchers.forEach(function(watcher) {
-    clearInterval(watcher.intervar);
+    clearInterval(watcher.interval);
   });
 
   this._watchers = [];


### PR DESCRIPTION
Typos apparently prevent portastic from stopping.  Changes watcher.intervar to watcher.interval as it seems to need.