### PR TITLE
Find function does not stop testing ports

### DIFF
--- a/lib/portastic.js
+++ b/lib/portastic.js
@@ -118,38 +118,43 @@ module.exports = {
     log('Trying to find open ports between range %s and %s', options.min,
       options.max);
 
-    var promise = bluebird.resolve(ports)
-      .each(function(port) {
-        return that.test(port, iface)
-          .then(function(open) {
-            if (options.retrieve && result.length >= options.retrieve) {
-              log('Result reached the maximum of %s ports, returning...',
-                options.retrieve);
-              return promise.cancel();
-            }
+    return new Promise(function (resolve) {
+      test(0);
 
-            if (open) {
-              log('Port %s was open, adding it to the result list', port);
-              log('Pushing port %s to the result list', port);
-              return result.push(port);
-            } else
-              log('Port %s was not open', port);
-          });
-      })
-      .cancellable()
-      .catch(bluebird.CancellationError, function() {
-        return;
-      })
-      .then(function() {
-        if (!that._callback(callback, [ports]))
-          return result;
-      })
-      .catch(function(err) {
-        if (!that._callback(callback, [err]))
-          throw err;
-      });
+      function test (i) {
+        const port = ports[i];
+        that.test(port, iface).then(function (open) {
+          if (open) {
+            log('Port %s was open, adding it to the result list', port);
+            log('Pushing port %s to the result list', port);
+            result.push(port);
+          } else {
+            log('Port %s was not open', port);
+          }
+  
+          if (options.retrieve && result.length >= options.retrieve) {
+            log('Result reached the maximum of %s ports, returning...',
+              options.retrieve);
+            return resolve(result);
+          }
 
-    return promise;
+          if (i === ports.length - 1) {
+            return resolve(result);
+          }
+
+          i++;
+  
+          test(i);
+        })
+      }
+    }).then(function() {
+      if (!that._callback(callback, [ports]))
+        return result;
+    })
+    .catch(function(err) {
+      if (!that._callback(callback, [err]))
+        throw err;
+    });
   }),
 
   // Handles callbacks


### PR DESCRIPTION
This is a problem I found while using https://www.npmjs.com/package/proxy-chain.

# Explanation
The proxy-chain module has a function to create a proxy server using a random open port, it finds the port using portastic. One of the ports that was tested gave an error and my PC would freeze for a few seconds after making the proxy server.

![image](https://user-images.githubusercontent.com/21038945/77129190-53dc5580-6a53-11ea-845e-d96111885329.png)

I am not sure why my PC freezes, but it is a result of the rejection.

The rejection comes from portastic. It would reject on errors that would occure when opening a server. It rejects after the proxy server is made, so something was messing things up in the background while the server was working fine.

The rejection comes from https://github.com/alanhoff/node-portastic/blob/d27c7d4d5c2eee620aff5e5f7804c28c78848ff0/lib/portastic.js#L37 and / or https://github.com/alanhoff/node-portastic/blob/d27c7d4d5c2eee620aff5e5f7804c28c78848ff0/lib/portastic.js#L53

The rejection is fine, it is just because it is not caught. But when using the find function all exceptions should be caught anyway. I don't change that in this pull request, because I don't think it is that big of a problem.

The biggest issue, and the reason for this pull request, is that the find function does not cancel when it finds the asked amount of open ports. Proxy-chain tells portastic to find a single open port in the range 20000 to 60000, but portastic fails to stop testing ports / cancel the promise.

I have replaced it with a recursive function, that way it is easier to control when the find function should stop, and _actually make it stop_.

# Replicate
To replicate the problem use the following code:

```js
process.env.DEBUG = 'portastic:*';

const portastic = require('portastic');

const opts = {
    min: 20000,
    max: 60000,
    retrieve: 1
};

console.log(opts);

portastic.find(opts).then(function (ports) {
    console.log(ports);
});
```

It will find the first open port and resolve the promise, but it will keep testing. See the image below for the debug log:
![image](https://user-images.githubusercontent.com/21038945/77129058-e3cdcf80-6a52-11ea-939f-3ed9fb5b2345.png)

With my fix:
![image](https://user-images.githubusercontent.com/21038945/77129094-f8aa6300-6a52-11ea-8054-089562d4927d.png)
